### PR TITLE
Implement DataSize for [T; N] using const generics

### DIFF
--- a/datasize/Cargo.toml
+++ b/datasize/Cargo.toml
@@ -9,13 +9,14 @@ documentation = "https://docs.rs/datasize"
 repository = "https://github.com/casperlabs/datasize-rs"
 
 [features]
-default = [ "std" ]
+default = [ "std", "const-generics" ]
 detailed = [ "std", "serde", "datasize_derive/detailed" ]
 fake_clock-types = [ "fake_instant" ]
 futures-types = [ "futures" ]
 smallvec-types = [ "smallvec", "std" ]
 std = []
 tokio-types = [ "tokio" ]
+const-generics = []
 
 [dependencies]
 datasize_derive = { version = "0.2.13" }


### PR DESCRIPTION
This is more general and more flexible than the fixed sizes already implemented.

The new implementation is gated by a new `const-generics` feature flag (and the old one is kept for backwards compatibility), as documented.