### PR TITLE
use qualified path for derivation

### DIFF
--- a/datasize/Cargo.toml
+++ b/datasize/Cargo.toml
@@ -19,7 +19,7 @@ tokio-types = [ "tokio" ]
 const-generics = []
 
 [dependencies]
-datasize_derive = { version = "0.2.15" }
+datasize_derive = { path = "../datasize_derive" }
 fake_instant = { version = "0.4.0", optional = true }
 futures = { version = "0.3.5", optional = true }
 serde = { version = "1", optional = true, features = [ "derive" ] }

--- a/datasize/Cargo.toml
+++ b/datasize/Cargo.toml
@@ -19,7 +19,7 @@ tokio-types = [ "tokio" ]
 const-generics = []
 
 [dependencies]
-datasize_derive = { path = "../datasize_derive" }
+datasize_derive = { version = "0.2.15" }
 fake_instant = { version = "0.4.0", optional = true }
 futures = { version = "0.3.5", optional = true }
 serde = { version = "1", optional = true, features = [ "derive" ] }

--- a/datasize_derive/src/lib.rs
+++ b/datasize_derive/src/lib.rs
@@ -443,7 +443,7 @@ fn derive_for_enum(name: Ident, generics: Generics, de: DataEnum) -> TokenStream
                         if !field_calc.is_empty() {
                             field_calc.extend(quote!(+));
                         }
-                        field_calc.extend(quote!(DataSize::estimate_heap_size(#ident)));
+                        field_calc.extend(quote!(datasize::DataSize::estimate_heap_size(#ident)));
                     }
                 }
 
@@ -468,7 +468,7 @@ fn derive_for_enum(name: Ident, generics: Generics, de: DataEnum) -> TokenStream
                         if !field_calc.is_empty() {
                             field_calc.extend(quote!(+));
                         }
-                        field_calc.extend(quote!(DataSize::estimate_heap_size(#ident)));
+                        field_calc.extend(quote!(datasize::DataSize::estimate_heap_size(#ident)));
 
                         let ty = field.ty;
                         where_types.extend(quote!(#ty : datasize::DataSize,));
@@ -529,7 +529,7 @@ fn derive_for_enum(name: Ident, generics: Generics, de: DataEnum) -> TokenStream
     }
 
     TokenStream::from(quote! {
-        impl #generics DataSize for #name #generics #where_clause {
+        impl #generics datasize::DataSize for #name #generics #where_clause {
 
             const IS_DYNAMIC: bool = #is_dynamic;
             const STATIC_HEAP_SIZE: usize = #static_heap_size;


### PR DESCRIPTION
Hi and thanks for your work!

I find the derived code assuming that the trait `DataSize` is already imported into the current scope. This is not a big deal but when I'm going to derive `DataSize` in generated protobuf code (with `prost`), I find no way to include the statement `use datasize::DataSize;`, especially for the nested modules.

So I guess the best way to resolve this issue is to use qualified path everywhere in the derived code.