### PR TITLE
smallvec: count children even if unspilled

### DIFF
--- a/datasize/src/smallvec.rs
+++ b/datasize/src/smallvec.rs
@@ -1,5 +1,6 @@
-use super::DataSize;
 use core::mem::size_of;
+
+use super::DataSize;
 
 impl<A> DataSize for smallvec::SmallVec<A>
 where
@@ -7,25 +8,61 @@ where
     A::Item: DataSize,
 {
     const IS_DYNAMIC: bool = true;
-
     const STATIC_HEAP_SIZE: usize = 0;
 
     #[inline]
     fn estimate_heap_size(&self) -> usize {
-        if !self.spilled() {
-            return 0;
-        }
-
-        // At this point, we're very similar to a regular `Vec`.
-
-        let sz_base = self.capacity() * size_of::<A::Item>();
+        let sz_base = if self.spilled() {
+            // At this point, we're very similar to a regular `Vec`.
+            self.capacity() * size_of::<A::Item>()
+        } else {
+            0
+        };
 
         let sz_used = if A::Item::IS_DYNAMIC {
-            self.iter().map(DataSize::estimate_heap_size).sum()
+            self.iter()
+                .map(DataSize::estimate_heap_size)
+                .sum()
         } else {
             self.len() * A::Item::STATIC_HEAP_SIZE
         };
 
         sz_base + sz_used
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::DataSize;
+
+    struct Test;
+
+    impl DataSize for Test {
+        const IS_DYNAMIC: bool = false;
+        const STATIC_HEAP_SIZE: usize = 1;
+
+        #[inline]
+        fn estimate_heap_size(&self) -> usize {
+            Self::STATIC_HEAP_SIZE
+        }
+    }
+
+    #[test]
+    fn nonspilled_smallvec_counts_children() {
+        let mut v = smallvec::SmallVec::<[Test; 1]>::new();
+        assert_eq!(v.estimate_heap_size(), 0);
+
+        v.push(Test);
+        assert_eq!(v.estimate_heap_size(), Test::STATIC_HEAP_SIZE);
+    }
+
+    #[test]
+    fn spilled_smallvec_counts_children() {
+        let mut v = smallvec::SmallVec::<[Test; 1]>::new();
+        assert_eq!(v.estimate_heap_size(), 0);
+
+        v.push(Test);
+        v.push(Test);
+        assert_eq!(v.estimate_heap_size(), Test::STATIC_HEAP_SIZE * 2);
     }
 }


### PR DESCRIPTION
We only want to not count children towards our own allocation, not skip calculating their own used size